### PR TITLE
Fix encoded string parsing

### DIFF
--- a/test/pjson/escaping_test.clj
+++ b/test/pjson/escaping_test.clj
@@ -1,17 +1,13 @@
 (ns
-  ^{:doc "Test reading data that has characters {} [] in the string values of lazy objects do not throw exceptions"}
-  pjson.escaping-test
+    ^{:doc "Test reading data that has characters {} [] in the string values of lazy objects do not throw exceptions"}
+    pjson.escaping-test
   (:require
-    [pjson.core :as pjson]
-    [cheshire.core :as cheshire]
-    [clojure.test :refer :all]))
-
-
+   [pjson.core :as pjson]
+   [cheshire.core :as cheshire]
+   [clojure.test :refer :all]))
 
 (def ^String CONVERSION-MSG-OBJ "{\"mykey\":{\"mykey2\": \"abc}\"}}")
 (def ^String CONVERSION-MSG-LIST "{\"mykey\":[\"mykey2\", \"abc]\"]}")
-
-
 
 (defn test-fail-message
   "Throw an exception if the message is not correct"
@@ -19,28 +15,21 @@
   (cheshire/parse-string (pjson/write-str (pjson/read-str msg))))
 
 (deftest test-conversion-lazy-obj []
-         (is (not (nil? (test-fail-message CONVERSION-MSG-OBJ)))))
-
-
+  (is (not (nil? (test-fail-message CONVERSION-MSG-OBJ)))))
 
 (deftest test-conversion-lazy-list []
-         (is (not (nil? (test-fail-message CONVERSION-MSG-LIST)))))
-
+  (is (not (nil? (test-fail-message CONVERSION-MSG-LIST)))))
 
 (deftest test-read-escapes []
-                           (let [data [
-                                       ["{\"a\": \"a\\ \\ a\"}"      {"a" "a\\\\a"}]
-                                       ["[{\"a\":\"J\\\\\\\"\"}]"  [{"a" "J\\\\"}]
-                                        "[{\"a\":\"J\\\\\"}]"      [{"a" "J\\"}]]]
-
-                                 test-fn (fn [[t result]]
-                                              (= (pjson/read-str t) result))]
-                             (is (every? test-fn data))))
+  (are [source expected-parsed] (= expected-parsed (pjson/read-str source))
+    "{\"a\": \"a\\ \\ a\"}"   {"a" "a  a"}
+    "[{\"a\":\"J\\\\\\\"\"}]" [{"a" "J\\"}]
+    "[{\"a\":\"J\\\\\"}]"     [{"a" "J\\"}]
+    "[\"\\n\"]"               ["\n"]))
 
 (deftest test-write-escapes []
-                           (let [data [[["b\\"] "[\"b\\\\\"]"]]
+  (let [data [[["b\\"] "[\"b\\\\\"]"]]
 
-                                 test-fn (fn [[t result]]
-                                           (= (pjson/write-str t) result))]
-                             (is (every? test-fn data))))
-
+        test-fn (fn [[t result]]
+                  (= (pjson/write-str t) result))]
+    (is (every? test-fn data))))


### PR DESCRIPTION
Hopefully fixing #31, here's what was done:

- use `clojure.test/are` for table-like tests
- verify expected output to be equal to what JavaScript `JSON.parse` outputs